### PR TITLE
Add admin Vercel routing

### DIFF
--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -1,0 +1,15 @@
+{
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/dashboard",
+      "permanent": false
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Adds admin/vercel.json so Vercel serves the React Router SPA for direct routes like /dashboard and redirects / to /dashboard.

Checks:
- cd admin && npm run build
- cd admin && npm run lint