### PR TITLE
connect db in serverless routes

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import cors from "cors";
 import express from "express";
 
+import { connectDb } from "./db";
 import activityRoutes from "./routes/activity";
 
 import type { NextFunction, Request, Response } from "express";
@@ -20,6 +21,15 @@ app.use(
 if (!process.env.VERCEL) {
   app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 }
+
+app.use(async (_req: Request, _res: Response, next: NextFunction) => {
+  try {
+    await connectDb();
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
 
 app.use("/api/activities", activityRoutes);
 

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,0 +1,20 @@
+import mongoose from "mongoose";
+
+let connectionPromise: Promise<typeof mongoose> | null = null;
+
+export async function connectDb() {
+  if (mongoose.connection.readyState === 1) {
+    return mongoose;
+  }
+
+  if (!process.env.MONGODB_URI) {
+    throw new Error("Missing MONGODB_URI environment variable");
+  }
+
+  connectionPromise ??= mongoose.connect(process.env.MONGODB_URI).catch((error: unknown) => {
+    connectionPromise = null;
+    throw error;
+  });
+
+  return connectionPromise;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,17 +3,15 @@
  */
 
 import dotenv from "dotenv";
-import mongoose from "mongoose";
 
 import app from "./app";
+import { connectDb } from "./db";
 
 dotenv.config();
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
-const MONGODB_URI = process.env.MONGODB_URI as string;
 
-mongoose
-  .connect(MONGODB_URI)
+connectDb()
   .then(() => {
     console.info("Mongoose connected!");
     app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add a cached MongoDB connection helper
- ensure API requests connect to Mongo before activity routes run in serverless deployments
- keep local server startup using the same connection helper

## Checks
- npm run build
- npm run lint-check
- local GET /api/activities returned 200 against the configured MongoDB