### PR TITLE
Add videoUrl and YouTube thumbnail support

### DIFF
--- a/admin/src/types/activity.ts
+++ b/admin/src/types/activity.ts
@@ -36,7 +36,8 @@ export type Activity = {
   title: string;
   overview: string;
   thumbnailUrl?: string;
-  additionalMedia?: { type: "image" | "video"; url: string }[];
+  videoUrl?: string;
+  additionalMedia?: { type: "image"; url: string }[];
   category: Category[];
   gradeRange: Range;
   groupSize: { min: number; max: number; anySize: boolean };

--- a/backend/docs/API_CONTRACTS.md
+++ b/backend/docs/API_CONTRACTS.md
@@ -20,8 +20,9 @@ type Activity = {
   _id: string;
   title: string;
   overview: string;
-  thumbnailUrl?: string;
-  additionalMedia?: { type: "image" | "video"; url: string }[];
+  thumbnailUrl?: string; // uploaded image, or YouTube thumbnail when only videoUrl is set
+  videoUrl?: string; // YouTube link for activity video
+  additionalMedia?: { type: "image"; url: string }[];
   category: Category[]; // 1–3 items
   gradeRange: { min: number; max: number }; // K = 0
   groupSize: { min: number; max: number; anySize: boolean };
@@ -224,9 +225,10 @@ Content-Type: multipart/form-data
 
 | Field         | Type   | Required | Description                                                               |
 | ------------- | ------ | -------- | ------------------------------------------------------------------------- |
-| `file`        | File   | Yes      | Image or video file (jpg, png, gif, webp, mp4, webm, mov)                 |
-| `mediaTarget` | string | Yes      | `"thumbnail"` or `"additional"`                                           |
-| `mediaType`   | string | No       | `"image"` or `"video"` (for additional media only, defaults to `"image"`) |
+| `file`        | File   | Yes      | Image file only (jpg, jpeg, png, gif, webp)                               |
+| `mediaTarget` | string | Yes      | `"thumbnail"` sets `thumbnailUrl`, or `"additional"` adds to `additionalMedia` |
+
+**Thumbnail behavior:** If `mediaTarget` is `"thumbnail"`, the uploaded image is stored as `thumbnailUrl`. On create/update, when `thumbnailUrl` is omitted but `videoUrl` is a YouTube link, the API sets `thumbnailUrl` to the YouTube preview image automatically.
 
 **Max file size:** 10 MB
 

--- a/backend/docs/API_CONTRACTS.md
+++ b/backend/docs/API_CONTRACTS.md
@@ -223,9 +223,9 @@ Content-Type: multipart/form-data
 
 **Form Fields:**
 
-| Field         | Type   | Required | Description                                                               |
-| ------------- | ------ | -------- | ------------------------------------------------------------------------- |
-| `file`        | File   | Yes      | Image file only (jpg, jpeg, png, gif, webp)                               |
+| Field         | Type   | Required | Description                                                                    |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------------ |
+| `file`        | File   | Yes      | Image file only (jpg, jpeg, png, gif, webp)                                    |
 | `mediaTarget` | string | Yes      | `"thumbnail"` sets `thumbnailUrl`, or `"additional"` adds to `additionalMedia` |
 
 **Thumbnail behavior:** If `mediaTarget` is `"thumbnail"`, the uploaded image is stored as `thumbnailUrl`. On create/update, when `thumbnailUrl` is omitted but `videoUrl` is a YouTube link, the API sets `thumbnailUrl` to the YouTube preview image automatically.

--- a/backend/src/controllers/activity.ts
+++ b/backend/src/controllers/activity.ts
@@ -137,7 +137,11 @@ export async function updateActivityStatus(req: Request, res: Response) {
   }
 
   const id = routeParam(req.params.id);
-  const activity = await Activity.findByIdAndUpdate(id, { status }, { new: true, runValidators: true });
+  const activity = await Activity.findByIdAndUpdate(
+    id,
+    { status },
+    { new: true, runValidators: true },
+  );
   if (!activity) {
     res.status(404).json({ error: "Activity not found" });
     return;

--- a/backend/src/controllers/activity.ts
+++ b/backend/src/controllers/activity.ts
@@ -2,8 +2,43 @@ import { isValidObjectId } from "mongoose";
 
 import Activity from "../models/activity";
 import { uploadActivityMedia } from "../services/firebaseStorage";
+import { resolveThumbnailUrl } from "../utils/activity-thumbnail";
 
 import type { Request, Response } from "express";
+
+function routeParam(value: string | string[] | undefined): string {
+  if (value === undefined) return "";
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function applyThumbnailFields(body: Record<string, unknown>): Record<string, unknown> {
+  const thumbnailUrl = resolveThumbnailUrl(
+    body.thumbnailUrl as string | undefined,
+    body.videoUrl as string | undefined,
+  );
+  if (thumbnailUrl !== undefined) {
+    return { ...body, thumbnailUrl };
+  }
+  return body;
+}
+
+async function applyThumbnailFieldsForUpdate(
+  id: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const existing = await Activity.findById(id).select("thumbnailUrl videoUrl").lean();
+  if (!existing) return body;
+
+  const thumbnailUrl = resolveThumbnailUrl(
+    (body.thumbnailUrl as string | undefined) ?? existing.thumbnailUrl,
+    (body.videoUrl as string | undefined) ?? existing.videoUrl,
+  );
+
+  if (thumbnailUrl !== undefined) {
+    return { ...body, thumbnailUrl };
+  }
+  return body;
+}
 
 type AggregateRow = { _id: string; count: number };
 
@@ -60,12 +95,13 @@ export async function listActivities(req: Request, res: Response) {
 }
 
 export async function getActivity(req: Request, res: Response) {
-  if (!isValidObjectId(req.params.id)) {
+  const id = routeParam(req.params.id);
+  if (!isValidObjectId(id)) {
     res.status(400).json({ error: "Invalid activity id" });
     return;
   }
 
-  const activity = await Activity.findById(req.params.id);
+  const activity = await Activity.findById(id);
   if (!activity) {
     res.status(404).json({ error: "Activity not found" });
     return;
@@ -74,14 +110,15 @@ export async function getActivity(req: Request, res: Response) {
 }
 
 export async function createActivity(req: Request, res: Response) {
-  const body = req.body as Record<string, unknown>;
+  const body = applyThumbnailFields(req.body as Record<string, unknown>);
   const activity = await Activity.create({ ...body, status: "Draft" });
   res.status(201).json(activity);
 }
 
 export async function updateActivity(req: Request, res: Response) {
-  const body = req.body as Record<string, unknown>;
-  const activity = await Activity.findByIdAndUpdate(req.params.id, body, {
+  const id = routeParam(req.params.id);
+  const body = await applyThumbnailFieldsForUpdate(id, req.body as Record<string, unknown>);
+  const activity = await Activity.findByIdAndUpdate(id, body, {
     new: true,
     runValidators: true,
   });
@@ -99,11 +136,8 @@ export async function updateActivityStatus(req: Request, res: Response) {
     return;
   }
 
-  const activity = await Activity.findByIdAndUpdate(
-    req.params.id,
-    { status },
-    { new: true, runValidators: true },
-  );
+  const id = routeParam(req.params.id);
+  const activity = await Activity.findByIdAndUpdate(id, { status }, { new: true, runValidators: true });
   if (!activity) {
     res.status(404).json({ error: "Activity not found" });
     return;
@@ -112,7 +146,8 @@ export async function updateActivityStatus(req: Request, res: Response) {
 }
 
 export async function deleteActivity(req: Request, res: Response) {
-  const activity = await Activity.findByIdAndDelete(req.params.id);
+  const id = routeParam(req.params.id);
+  const activity = await Activity.findByIdAndDelete(id);
   if (!activity) {
     res.status(404).json({ error: "Activity not found" });
     return;
@@ -126,8 +161,8 @@ export async function uploadMedia(req: Request, res: Response) {
     return;
   }
 
-  const activityId = req.params.id;
-  if (Array.isArray(activityId)) {
+  const activityId = routeParam(req.params.id);
+  if (!isValidObjectId(activityId)) {
     res.status(400).json({ error: "Invalid activity id" });
     return;
   }
@@ -139,15 +174,14 @@ export async function uploadMedia(req: Request, res: Response) {
   }
 
   const fileUrl = await uploadActivityMedia(req.file, activityId);
-  const body = (req.body ?? {}) as { mediaTarget?: string; mediaType?: string };
+  const body = (req.body ?? {}) as { mediaTarget?: string };
   const mediaTarget = body.mediaTarget;
 
   if (mediaTarget === "thumbnail") {
     await Activity.findByIdAndUpdate(activityId, { thumbnailUrl: fileUrl });
   } else if (mediaTarget === "additional") {
-    const mediaType = body.mediaType === "video" ? "video" : "image";
     await Activity.findByIdAndUpdate(activityId, {
-      $push: { additionalMedia: { type: mediaType, url: fileUrl } },
+      $push: { additionalMedia: { type: "image", url: fileUrl } },
     });
   } else {
     res.status(400).json({ error: "Invalid mediaTarget." });

--- a/backend/src/models/activity.ts
+++ b/backend/src/models/activity.ts
@@ -4,7 +4,7 @@ import type { InferSchemaType } from "mongoose";
 
 const additionalMediaSchema = new Schema(
   {
-    type: { type: String, enum: ["image", "video"], required: true },
+    type: { type: String, enum: ["image"], required: true, default: "image" },
     url: { type: String, required: true },
   },
   { _id: false },
@@ -23,6 +23,7 @@ const activitySchema = new Schema(
     title: { type: String, required: true },
     overview: { type: String, required: true },
     thumbnailUrl: { type: String },
+    videoUrl: { type: String },
     additionalMedia: [additionalMediaSchema],
     category: {
       type: [String],

--- a/backend/src/routes/activity.ts
+++ b/backend/src/routes/activity.ts
@@ -20,11 +20,11 @@ const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 10 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
-    const allowed = /\.(?:jpg|jpeg|png|gif|webp|mp4|webm|mov)$/i;
+    const allowed = /\.(?:jpg|jpeg|png|gif|webp)$/i;
     if (allowed.test(path.extname(file.originalname))) {
       cb(null, true);
     } else {
-      cb(new Error("Only image and video files are allowed"));
+      cb(new Error("Only image files are allowed (jpg, jpeg, png, gif, webp)"));
     }
   },
 });

--- a/backend/src/utils/activity-thumbnail.ts
+++ b/backend/src/utils/activity-thumbnail.ts
@@ -1,0 +1,17 @@
+import { getYouTubeThumbnailUrl } from "./youtube";
+
+/**
+ * Prefer an uploaded image thumbnail; otherwise derive from YouTube when videoUrl is set.
+ */
+export function resolveThumbnailUrl(
+  thumbnailUrl: string | undefined | null,
+  videoUrl: string | undefined | null,
+): string | undefined {
+  const thumb = thumbnailUrl?.trim();
+  if (thumb) return thumb;
+
+  const video = videoUrl?.trim();
+  if (!video) return undefined;
+
+  return getYouTubeThumbnailUrl(video) ?? undefined;
+}

--- a/backend/src/utils/youtube.ts
+++ b/backend/src/utils/youtube.ts
@@ -1,0 +1,36 @@
+/**
+ * Parse YouTube URLs and build thumbnail image URLs.
+ */
+
+export function getYouTubeVideoId(url: string): string | null {
+  if (!url?.trim()) return null;
+
+  try {
+    const parsed = new URL(url.trim());
+    const host = parsed.hostname.replace(/^www\./, "");
+
+    if (host === "youtu.be") {
+      const id = parsed.pathname.slice(1).split("/")[0];
+      return id.length === 11 ? id : null;
+    }
+
+    if (host === "youtube.com" || host === "m.youtube.com") {
+      const v = parsed.searchParams.get("v");
+      if (v && v.length === 11) return v;
+
+      const embedMatch = /^\/embed\/([^/?]+)/.exec(parsed.pathname);
+      if (embedMatch && embedMatch[1].length === 11) return embedMatch[1];
+    }
+  } catch {
+    // Fall through to regex for non-URL strings
+  }
+
+  const match = /(?:youtu\.be\/|v\/|embed\/|watch\?v=|&v=)([^#&?]{11})/.exec(url);
+  return match?.[1] ?? null;
+}
+
+export function getYouTubeThumbnailUrl(videoUrl: string): string | null {
+  const id = getYouTubeVideoId(videoUrl);
+  if (!id) return null;
+  return `https://img.youtube.com/vi/${id}/maxresdefault.jpg`;
+}


### PR DESCRIPTION
## Summary
1. Add optional `videoUrl` field to the Activity schema for YouTube links
2. Auto-set `thumbnailUrl` from YouTube when no image thumbnail is provided
3. Uploaded images still take priority as `thumbnailUrl`
4. Media upload endpoint accepts images only (no video file uploads)

## Test plan
1. [ ] `POST /api/activities` with `videoUrl` only → response includes YouTube `thumbnailUrl`
2. [ ] `POST /api/activities/:id/media` with image + `mediaTarget=thumbnail` → uploaded URL used
3. [ ] `PUT /api/activities/:id` with new `videoUrl` and no thumbnail → YouTube thumbnail applied
4. [ ] Upload `.mp4` → rejected with image-only error