### PR TITLE
Backend Code Quality Fixes

### DIFF
--- a/admin/src/types/activity.ts
+++ b/admin/src/types/activity.ts
@@ -26,6 +26,20 @@ export type Range = {
   max: number;
 };
 
+export type GroupSizeRange = {
+  anySize?: false;
+  min: number;
+  max: number;
+};
+
+export type GroupSizeAny = {
+  anySize: true;
+  min?: number;
+  max?: number;
+};
+
+export type GroupSize = GroupSizeRange | GroupSizeAny;
+
 export type FacilitateSection = {
   tabName: string;
   content: string;
@@ -40,7 +54,7 @@ export type Activity = {
   additionalMedia?: { type: "image"; url: string }[];
   category: Category[];
   gradeRange: Range;
-  groupSize: { min: number; max: number; anySize: boolean };
+  groupSize: GroupSize;
   duration: Duration;
   energyLevel: EnergyLevel;
   environment: Environment[];

--- a/backend/docs/API_CONTRACTS.md
+++ b/backend/docs/API_CONTRACTS.md
@@ -16,6 +16,20 @@ type Setup = "None" | "Required";
 type Duration = "5-15 min" | "15-30 min" | "30+ min";
 type Status = "Draft" | "Published" | "Archived";
 
+type GroupSizeRange = {
+  anySize?: false;
+  min: number;
+  max: number;
+};
+
+type GroupSizeAny = {
+  anySize: true;
+  min?: number;
+  max?: number;
+};
+
+type GroupSize = GroupSizeRange | GroupSizeAny;
+
 type Activity = {
   _id: string;
   title: string;
@@ -25,7 +39,7 @@ type Activity = {
   additionalMedia?: { type: "image"; url: string }[];
   category: Category[]; // 1–3 items
   gradeRange: { min: number; max: number }; // K = 0
-  groupSize: { min: number; max: number; anySize: boolean };
+  groupSize: GroupSize;
   duration: Duration;
   energyLevel: EnergyLevel;
   environment: Environment[];
@@ -104,6 +118,13 @@ Content-Type: application/json
 ```
 
 Status is always forced to `"Draft"` on creation regardless of what is sent in the body.
+
+**`groupSize` rules:**
+
+| Shape                                                                  | Required fields                                    |
+| ---------------------------------------------------------------------- | -------------------------------------------------- |
+| `{ "anySize": true }`                                                  | `anySize` only (`min` / `max` optional)            |
+| `{ "min": N, "max": M }` or `{ "min": N, "max": M, "anySize": false }` | `min` and `max` (positive integers, `min` ≤ `max`) |
 
 **Request Body:**
 
@@ -329,6 +350,26 @@ curl -X POST http://localhost:4000/api/activities \
     ],
     "materials": [],
     "selTags": ["teamwork"]
+  }'
+
+# Create a draft activity with any group size
+curl -X POST http://localhost:4000/api/activities \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Moon Ball",
+    "overview": "Keep a large ball aloft while adding movement challenges.",
+    "category": ["Active", "Connection"],
+    "gradeRange": { "min": 0, "max": 12 },
+    "groupSize": { "anySize": true },
+    "duration": "5-15 min",
+    "energyLevel": "Medium",
+    "environment": ["Gym/MPR"],
+    "setup": "Required",
+    "facilitateSections": [
+      { "tabName": "Play", "content": "Volley the ball; add rules each round." }
+    ],
+    "materials": ["Large beach ball"],
+    "selTags": ["Cooperation"]
   }'
 
 # Publish it (replace <id> with the _id from above)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "express-validator": "^7.3.2",
         "firebase-admin": "^13.10.0",
         "mongoose": "^9.1.1",
         "multer": "^2.1.1"
@@ -4308,6 +4309,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+      "integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.18.1",
+        "validator": "~13.15.23"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -6240,7 +6254,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -9875,6 +9888,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "express-validator": "^7.3.2",
     "firebase-admin": "^13.10.0",
     "mongoose": "^9.1.1",
     "multer": "^2.1.1"

--- a/backend/src/constants/activity.ts
+++ b/backend/src/constants/activity.ts
@@ -1,0 +1,33 @@
+export const ACTIVITY_STATUSES = ["Draft", "Published", "Archived"] as const;
+
+export const ACTIVITY_CATEGORIES = [
+  "Opener",
+  "Icebreaker",
+  "Active",
+  "Connection",
+  "Debrief",
+  "Team Challenge",
+] as const;
+
+export const ACTIVITY_ENERGY_LEVELS = ["Low", "Medium", "High"] as const;
+
+export const ACTIVITY_ENVIRONMENTS = [
+  "Blacktop",
+  "Field",
+  "Classroom",
+  "Gym/MPR",
+  "Any Environment",
+] as const;
+
+export const ACTIVITY_SETUPS = ["None", "Required"] as const;
+
+export const ACTIVITY_DURATIONS = ["5-15 min", "15-30 min", "30+ min"] as const;
+
+export const ACTIVITY_SORT_FIELDS = [
+  "createdAt",
+  "updatedAt",
+  "title",
+  "energyLevel",
+  "duration",
+  "status",
+] as const;

--- a/backend/src/middleware/validateRequest.ts
+++ b/backend/src/middleware/validateRequest.ts
@@ -1,0 +1,20 @@
+import { validationResult } from "express-validator";
+
+import type { NextFunction, Request, Response } from "express";
+
+function firstValidationMessage(req: Request): string {
+  const [firstError] = validationResult(req).array({ onlyFirstError: true });
+  if (firstError && "msg" in firstError && typeof firstError.msg === "string") {
+    return firstError.msg;
+  }
+  return "Invalid request.";
+}
+
+export function validateRequest(req: Request, res: Response, next: NextFunction): void {
+  const result = validationResult(req);
+  if (!result.isEmpty()) {
+    res.status(400).json({ error: firstValidationMessage(req) });
+    return;
+  }
+  next();
+}

--- a/backend/src/models/activity.ts
+++ b/backend/src/models/activity.ts
@@ -18,6 +18,27 @@ const facilitateSectionSchema = new Schema(
   { _id: false },
 );
 
+type GroupSizeDoc = { anySize?: boolean };
+
+const groupSizeSchema = new Schema(
+  {
+    min: {
+      type: Number,
+      required: function groupSizeMinRequired(this: GroupSizeDoc) {
+        return !this.anySize;
+      },
+    },
+    max: {
+      type: Number,
+      required: function groupSizeMaxRequired(this: GroupSizeDoc) {
+        return !this.anySize;
+      },
+    },
+    anySize: { type: Boolean, default: false },
+  },
+  { _id: false },
+);
+
 const activitySchema = new Schema(
   {
     title: { type: String, required: true },
@@ -38,11 +59,7 @@ const activitySchema = new Schema(
       min: { type: Number, required: true },
       max: { type: Number, required: true },
     },
-    groupSize: {
-      min: { type: Number, required: true },
-      max: { type: Number, required: true },
-      anySize: { type: Boolean, default: false },
-    },
+    groupSize: { type: groupSizeSchema, required: true },
     duration: {
       type: String,
       enum: ["5-15 min", "15-30 min", "30+ min"],

--- a/backend/src/routes/activity.ts
+++ b/backend/src/routes/activity.ts
@@ -13,6 +13,12 @@ import {
   updateActivityStatus,
   uploadMedia,
 } from "../controllers/activity";
+import { validateRequest } from "../middleware/validateRequest";
+import {
+  createActivityBody,
+  listActivitiesQuery,
+  updateActivityBody,
+} from "../validators/activity";
 
 const router = express.Router();
 
@@ -30,10 +36,10 @@ const upload = multer({
 });
 
 router.get("/stats", getActivityStats);
-router.get("/", listActivities);
+router.get("/", listActivitiesQuery, validateRequest, listActivities);
 router.get("/:id", getActivity);
-router.post("/", createActivity);
-router.put("/:id", updateActivity);
+router.post("/", createActivityBody, validateRequest, createActivity);
+router.put("/:id", updateActivityBody, validateRequest, updateActivity);
 router.patch("/:id/status", updateActivityStatus);
 router.delete("/:id", deleteActivity);
 router.post("/:id/media", upload.single("file"), uploadMedia);

--- a/backend/src/validators/activity.ts
+++ b/backend/src/validators/activity.ts
@@ -1,0 +1,227 @@
+import { body, query } from "express-validator";
+
+import {
+  ACTIVITY_CATEGORIES,
+  ACTIVITY_DURATIONS,
+  ACTIVITY_ENERGY_LEVELS,
+  ACTIVITY_ENVIRONMENTS,
+  ACTIVITY_SETUPS,
+  ACTIVITY_SORT_FIELDS,
+  ACTIVITY_STATUSES,
+} from "../constants/activity";
+
+import type { ValidationChain } from "express-validator";
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function categoryItemsValidator(value: unknown): boolean {
+  if (!isStringArray(value)) return false;
+  return value.every((item) => (ACTIVITY_CATEGORIES as readonly string[]).includes(item));
+}
+
+function environmentItemsValidator(value: unknown): boolean {
+  if (!isStringArray(value)) return false;
+  return value.every((item) => (ACTIVITY_ENVIRONMENTS as readonly string[]).includes(item));
+}
+
+const optionalActivityBodyFields: ValidationChain[] = [
+  body("thumbnailUrl").optional().isString(),
+  body("videoUrl").optional().isString(),
+  body("objective").optional().isString(),
+  body("category")
+    .optional()
+    .isArray({ min: 1, max: 3 })
+    .withMessage("category must have between 1 and 3 items.")
+    .custom(categoryItemsValidator)
+    .withMessage(`category must be one of: ${ACTIVITY_CATEGORIES.join(", ")}.`),
+  body("gradeRange").optional().isObject().withMessage("gradeRange must be an object."),
+  body("gradeRange.min")
+    .optional()
+    .isInt({ min: 0, max: 12 })
+    .withMessage("gradeRange.min must be between 0 and 12."),
+  body("gradeRange.max")
+    .optional()
+    .isInt({ min: 0, max: 12 })
+    .withMessage("gradeRange.max must be between 0 and 12."),
+  body("groupSize").optional().isObject().withMessage("groupSize must be an object."),
+  body("groupSize.min")
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage("groupSize.min must be a positive integer."),
+  body("groupSize.max")
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage("groupSize.max must be a positive integer."),
+  body("groupSize.anySize").optional().isBoolean(),
+  body("duration")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_DURATIONS)
+    .withMessage(`duration must be one of: ${ACTIVITY_DURATIONS.join(", ")}.`),
+  body("energyLevel")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_ENERGY_LEVELS)
+    .withMessage(`energyLevel must be one of: ${ACTIVITY_ENERGY_LEVELS.join(", ")}.`),
+  body("environment")
+    .optional()
+    .isArray({ min: 1 })
+    .custom(environmentItemsValidator)
+    .withMessage(`environment must be one of: ${ACTIVITY_ENVIRONMENTS.join(", ")}.`),
+  body("setup")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_SETUPS)
+    .withMessage(`setup must be one of: ${ACTIVITY_SETUPS.join(", ")}.`),
+  body("facilitateSections").optional().isArray(),
+  body("facilitateSections.*.tabName")
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("facilitateSections tabName is required."),
+  body("facilitateSections.*.content")
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("facilitateSections content is required."),
+  body("materials").optional().isArray(),
+  body("materials.*").optional().isString(),
+  body("selTags").optional().isArray(),
+  body("selTags.*").optional().isString(),
+  body("status")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_STATUSES)
+    .withMessage(`status must be one of: ${ACTIVITY_STATUSES.join(", ")}.`),
+];
+
+const optionalCreateOnlyFields: ValidationChain[] = [
+  body("thumbnailUrl").optional().isString(),
+  body("videoUrl").optional().isString(),
+  body("objective").optional().isString(),
+  body("groupSize.anySize").optional().isBoolean(),
+  body("environment")
+    .optional()
+    .isArray({ min: 1 })
+    .custom(environmentItemsValidator)
+    .withMessage(`environment must be one of: ${ACTIVITY_ENVIRONMENTS.join(", ")}.`),
+  body("setup")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_SETUPS)
+    .withMessage(`setup must be one of: ${ACTIVITY_SETUPS.join(", ")}.`),
+  body("facilitateSections").optional().isArray(),
+  body("facilitateSections.*.tabName")
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("facilitateSections tabName is required."),
+  body("facilitateSections.*.content")
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage("facilitateSections content is required."),
+  body("materials").optional().isArray(),
+  body("materials.*").optional().isString(),
+  body("selTags").optional().isArray(),
+  body("selTags.*").optional().isString(),
+];
+
+export const listActivitiesQuery: ValidationChain[] = [
+  query("status")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_STATUSES)
+    .withMessage(`status must be one of: ${ACTIVITY_STATUSES.join(", ")}.`),
+  query("search").optional().isString().withMessage("search must be a string."),
+  query("category")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_CATEGORIES)
+    .withMessage(`category must be one of: ${ACTIVITY_CATEGORIES.join(", ")}.`),
+  query("energyLevel")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_ENERGY_LEVELS)
+    .withMessage(`energyLevel must be one of: ${ACTIVITY_ENERGY_LEVELS.join(", ")}.`),
+  query("environment")
+    .optional()
+    .isString()
+    .custom((value: string) => {
+      const environments = value
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+      if (environments.length === 0) {
+        throw new Error("environment must include at least one value.");
+      }
+      const invalid = environments.filter(
+        (part) => !(ACTIVITY_ENVIRONMENTS as readonly string[]).includes(part),
+      );
+      if (invalid.length > 0) {
+        throw new Error(`Invalid environment: ${invalid.join(", ")}.`);
+      }
+      return true;
+    }),
+  query("setup")
+    .optional()
+    .isString()
+    .isIn(ACTIVITY_SETUPS)
+    .withMessage(`setup must be one of: ${ACTIVITY_SETUPS.join(", ")}.`),
+  query("sort")
+    .optional()
+    .isString()
+    .custom((value: string) => {
+      const field = value.startsWith("-") ? value.slice(1) : value;
+      if (!(ACTIVITY_SORT_FIELDS as readonly string[]).includes(field)) {
+        throw new Error(`Invalid sort field. Allowed: ${ACTIVITY_SORT_FIELDS.join(", ")}.`);
+      }
+      return true;
+    }),
+  query("page").optional().isInt({ min: 1 }).withMessage("page must be a positive integer."),
+  query("limit")
+    .optional()
+    .isInt({ min: 1, max: 30 })
+    .withMessage("limit must be between 1 and 30."),
+];
+
+export const createActivityBody: ValidationChain[] = [
+  body("title").isString().trim().notEmpty().withMessage("title is required."),
+  body("overview").isString().trim().notEmpty().withMessage("overview is required."),
+  body("category")
+    .isArray({ min: 1, max: 3 })
+    .withMessage("category must have between 1 and 3 items.")
+    .custom(categoryItemsValidator)
+    .withMessage(`category must be one of: ${ACTIVITY_CATEGORIES.join(", ")}.`),
+  body("gradeRange").isObject().withMessage("gradeRange is required."),
+  body("gradeRange.min")
+    .isInt({ min: 0, max: 12 })
+    .withMessage("gradeRange.min must be between 0 and 12."),
+  body("gradeRange.max")
+    .isInt({ min: 0, max: 12 })
+    .withMessage("gradeRange.max must be between 0 and 12."),
+  body("groupSize").isObject().withMessage("groupSize is required."),
+  body("groupSize.min").isInt({ min: 1 }).withMessage("groupSize.min must be a positive integer."),
+  body("groupSize.max").isInt({ min: 1 }).withMessage("groupSize.max must be a positive integer."),
+  body("duration")
+    .isString()
+    .isIn(ACTIVITY_DURATIONS)
+    .withMessage(`duration must be one of: ${ACTIVITY_DURATIONS.join(", ")}.`),
+  body("energyLevel")
+    .isString()
+    .isIn(ACTIVITY_ENERGY_LEVELS)
+    .withMessage(`energyLevel must be one of: ${ACTIVITY_ENERGY_LEVELS.join(", ")}.`),
+  ...optionalCreateOnlyFields,
+];
+
+export const updateActivityBody: ValidationChain[] = [
+  body("title").optional().isString().trim().notEmpty().withMessage("title cannot be empty."),
+  body("overview").optional().isString().trim().notEmpty().withMessage("overview cannot be empty."),
+  ...optionalActivityBodyFields,
+];

--- a/backend/src/validators/activity.ts
+++ b/backend/src/validators/activity.ts
@@ -26,6 +26,47 @@ function environmentItemsValidator(value: unknown): boolean {
   return value.every((item) => (ACTIVITY_ENVIRONMENTS as readonly string[]).includes(item));
 }
 
+function parsePositiveInt(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const parsed = Number(value);
+    if (parsed >= 1) return parsed;
+  }
+  return null;
+}
+
+function validateGroupSize(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("groupSize must be an object.");
+  }
+
+  const groupSize = value as { min?: unknown; max?: unknown; anySize?: unknown };
+
+  if (groupSize.anySize !== undefined && typeof groupSize.anySize !== "boolean") {
+    throw new Error("groupSize.anySize must be a boolean.");
+  }
+
+  if (groupSize.anySize === true) {
+    return true;
+  }
+
+  const min = parsePositiveInt(groupSize.min);
+  const max = parsePositiveInt(groupSize.max);
+  if (min === null) {
+    throw new Error("groupSize.min must be a positive integer.");
+  }
+  if (max === null) {
+    throw new Error("groupSize.max must be a positive integer.");
+  }
+  if (min > max) {
+    throw new Error("groupSize.min cannot be greater than groupSize.max.");
+  }
+
+  return true;
+}
+
 const optionalActivityBodyFields: ValidationChain[] = [
   body("thumbnailUrl").optional().isString(),
   body("videoUrl").optional().isString(),
@@ -45,16 +86,7 @@ const optionalActivityBodyFields: ValidationChain[] = [
     .optional()
     .isInt({ min: 0, max: 12 })
     .withMessage("gradeRange.max must be between 0 and 12."),
-  body("groupSize").optional().isObject().withMessage("groupSize must be an object."),
-  body("groupSize.min")
-    .optional()
-    .isInt({ min: 1 })
-    .withMessage("groupSize.min must be a positive integer."),
-  body("groupSize.max")
-    .optional()
-    .isInt({ min: 1 })
-    .withMessage("groupSize.max must be a positive integer."),
-  body("groupSize.anySize").optional().isBoolean(),
+  body("groupSize").optional().custom(validateGroupSize),
   body("duration")
     .optional()
     .isString()
@@ -103,7 +135,6 @@ const optionalCreateOnlyFields: ValidationChain[] = [
   body("thumbnailUrl").optional().isString(),
   body("videoUrl").optional().isString(),
   body("objective").optional().isString(),
-  body("groupSize.anySize").optional().isBoolean(),
   body("environment")
     .optional()
     .isArray({ min: 1 })
@@ -206,9 +237,7 @@ export const createActivityBody: ValidationChain[] = [
   body("gradeRange.max")
     .isInt({ min: 0, max: 12 })
     .withMessage("gradeRange.max must be between 0 and 12."),
-  body("groupSize").isObject().withMessage("groupSize is required."),
-  body("groupSize.min").isInt({ min: 1 }).withMessage("groupSize.min must be a positive integer."),
-  body("groupSize.max").isInt({ min: 1 }).withMessage("groupSize.max must be a positive integer."),
+  body("groupSize").custom(validateGroupSize),
   body("duration")
     .isString()
     .isIn(ACTIVITY_DURATIONS)


### PR DESCRIPTION
## Summary
Backend code quality fixes to address the lack of validation for query parameters and the request body.

## Changes
<!-- List of specific changes made -->
- Every filter param (status, category, energyLevel, environment, setup, search, sort, page, limit) must be a plain string or int matching an allowlist before listActivities builds the Mongo filter
- Validate required/optional fields against the same enums as the schema
- Use express-validator for validation
- Fix issue where max and min fields were mandatory even when "any" size was selected

## Testing
<!-- How did you test these changes? -->
- Backend works properly

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Tested locally
- [x] No new warnings or errors